### PR TITLE
fix(Kafka): kafka trigger not work

### DIFF
--- a/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
@@ -204,7 +204,7 @@ export class KafkaTrigger implements INodeType {
 
 		const consumer = kafka.consumer({
 			groupId,
-			maxInFlightRequests: this.getNodeParameter('options.maxInFlightRequests', 0) as number,
+			maxInFlightRequests: (this.getNodeParameter('options.maxInFlightRequests', 0) as number) || null,
 			sessionTimeout: this.getNodeParameter('options.sessionTimeout', 30000) as number,
 			heartbeatInterval: this.getNodeParameter('options.heartbeatInterval', 3000) as number,
 		});


### PR DESCRIPTION
fix [issue 3886](https://github.com/n8n-io/n8n/issues/3886)
`maxInFlightRequests` default value is `null` not `0` for [kafkajs](https://github.com/tulios/kafkajs/blob/master/src/network/connection.js#L52)